### PR TITLE
빌드 실패하는 현상 해결

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,8 @@
-import org.springframework.boot.gradle.tasks.bundling.BootJar
-
 dependencies {
     api(project(":domain"))
     implementation("org.springframework.boot:spring-boot-starter-web")
+}
+
+jar {
+    enabled = false
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.springframework.boot.gradle.tasks.bundling.BootJar
 
 plugins {
 	val bootVer = "2.5.3"
@@ -68,4 +69,8 @@ subprojects {
 	tasks.withType<Test> {
 		useJUnitPlatform()
 	}
+}
+
+tasks.withType<BootJar> {
+	enabled = false
 }

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -4,3 +4,6 @@ dependencies {
     api("org.springframework.boot:spring-boot-starter-data-jpa")
 }
 
+tasks.bootJar {
+    enabled = false
+}


### PR DESCRIPTION
resolve #12 
- bootJar 가 필요하지 않은 root, domain 모듈은 `enabled=false` 로 설정
- api 모듈에서 *-plain.jar 생성하지 않음