### PR TITLE
feat: jasypt 설정 파일 암호화 라이브러리 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,7 +1,6 @@
 dependencies {
     api(project(":domain"))
     implementation("org.springframework.boot:spring-boot-starter-web")
-    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
 }
 
 jar {

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     api(project(":domain"))
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
 }
 
 jar {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
 }
 
 bootJar {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
-    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
+    api("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
 }
 
 bootJar {

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     runtimeOnly("com.h2database:h2")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
-    api("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
+    implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")
 }
 
 bootJar {

--- a/domain/src/main/kotlin/mashup/backend/spring/member/infrastructure/JasyptConfig.kt
+++ b/domain/src/main/kotlin/mashup/backend/spring/member/infrastructure/JasyptConfig.kt
@@ -1,0 +1,9 @@
+package mashup.backend.spring.member.infrastructure
+
+import com.ulisesbocchio.jasyptspringboot.annotation.EnableEncryptableProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableEncryptableProperties
+class JasyptConfig {
+}

--- a/domain/src/main/resources/application.yml
+++ b/domain/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+jasypt:
+  encryptor:
+    password: # inject from environment variable

--- a/domain/src/test/kotlin/mashup/backend/spring/member/infrastructure/EncryptionTest.kt
+++ b/domain/src/test/kotlin/mashup/backend/spring/member/infrastructure/EncryptionTest.kt
@@ -1,0 +1,50 @@
+package mashup.backend.spring.member.infrastructure
+
+import com.ulisesbocchio.jasyptspringboot.encryptor.DefaultLazyEncryptor
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.core.env.ConfigurableEnvironment
+import org.springframework.test.context.junit.jupiter.SpringExtension
+
+/**
+ * Run > Edit Configurations > Configuration > Environment variables > 'JASYPT_ENCRYPTOR_PASSWORD={암호화키}' 입력
+ */
+@Disabled("필요할 때만 사용하기 위해 disabled 처리함")
+@ExtendWith(SpringExtension::class)
+@SpringBootTest
+class EncryptionTest {
+    @Value("\${jasypt.encryptor.password}")
+    lateinit var jasyptEncryptorPassword: String
+    @Autowired
+    lateinit var configurableEnvironment: ConfigurableEnvironment
+
+    lateinit var encryptor: DefaultLazyEncryptor
+
+    @BeforeEach
+    internal fun setUp() {
+        check(jasyptEncryptorPassword.isNotBlank()) {
+            "jasypt.encryptor.password must not be null, empty or blank. "
+        }
+        encryptor = DefaultLazyEncryptor(configurableEnvironment)
+    }
+
+    @Test
+    fun testForEncryption() {
+        val source = "string want to encrypt"
+        println("source: $source")
+        println("encrypted: ${encryptor.encrypt(source)}")
+    }
+
+    @Test
+    fun testForDecryption() {
+        // 암호화 되지 않은 문자열을 넣으면 복호화시 에러 발생함
+        val source = "string want to decrypt"
+        println("source: $source")
+        println("decrypted: ${encryptor.decrypt(source)}")
+    }
+}


### PR DESCRIPTION
resolve #16 
- 설정파일 암호화/복호화 라이브러리 추가했습니다
- maven plugin 으로 편하게 사용할 수 있으나.. gradle 은 지원하지 않아서 ㅠㅠ 암호화/복호화 하는 테스트코드 추가했습니다
- 테스트코드는 평소에 disabled 해두고, 필요할 때 열어서 실행해보면 좋을거같아요
- 암호화/복호화 테스트 실행시 `JASYPT_ENCRYPTOR_PASSWORD` 환경변수가 필요합니다

```
sensitive.password=ENC(encrypted)
regular.property=example
```