### PR TITLE
MySQL 연동

### DIFF
--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     runtimeOnly("com.h2database:h2")
+    runtimeOnly("mysql:mysql-connector-java")
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     api("org.springframework.boot:spring-boot-starter-data-jpa")
     implementation("com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.3")

--- a/domain/src/main/resources/application-develop.yml
+++ b/domain/src/main/resources/application-develop.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:mysql://3.36.159.91:3306/member_dev?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: spring
+    password: ENC(iff8gDZ+DD3jE5Ekm6WHp8fbilspPmYSuXe1jA2rRPRIjpjhlAVbEjsDk+B0Kbwj)
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/domain/src/main/resources/application-local.yml
+++ b/domain/src/main/resources/application-local.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:mysql://3.36.159.91:3306/member_dev?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: spring
+    password: ENC(iff8gDZ+DD3jE5Ekm6WHp8fbilspPmYSuXe1jA2rRPRIjpjhlAVbEjsDk+B0Kbwj)
+  jpa:
+    hibernate:
+      ddl-auto: update

--- a/domain/src/main/resources/application-production.yml
+++ b/domain/src/main/resources/application-production.yml
@@ -1,0 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:mysql://3.36.159.91:3306/member?useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul
+    username: spring
+    password: ENC(iff8gDZ+DD3jE5Ekm6WHp8fbilspPmYSuXe1jA2rRPRIjpjhlAVbEjsDk+B0Kbwj)
+  jpa:
+    hibernate:
+      ddl-auto: none


### PR DESCRIPTION
resolve #18 

- base 브랜치는 머지할 때 develop 으로 변경할게요! 암호화/복호화 라이브러리 사용하려고 아래 PR 위에서 브랜치 만들었더니 중복되는 diff 가 많아서.. base 브랜치 이렇게 해놓았습니다 (https://github.com/mash-up-kr/Elegant_Spring_Family_Member/pull/17)
- `useSSL=false&useUnicode=true&characterEncoding=utf8&serverTimezone=Asia/Seoul` 이 옵션들은 어딘가에서 복사해온거라서.. 필요하면 더 추가해도됩니다! 
- db 접속 정보는 복호화해서 보셔도되고, 슬랙에도 공유해두겠습니다

### Version
```
MySQL 8.0.23
```

### profile 별 설정
| spring profile | schema | ddl-auto strategy |
|-|-|-|
| local | member_dev | update | 
| develop | member_dev | update |
| production | member | none |

