### PR TITLE
api 모듈 테스트 실패하는 현상 해결

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation("io.springfox:springfox-swagger2:2.9.2")
     implementation("io.springfox:springfox-swagger-ui:2.9.2")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    testRuntimeOnly("com.h2database:h2")
 }
 
 jar {


### PR DESCRIPTION
resolve #12 

### AS-IS
- api 모듈에 h2 driver 가 없어서 테스트, 빌드 실패

### TO-BE
- api 모듈에 h2 driver 의존성 추가 (testRuntimeOnly)
- 테스트, 빌드 성공