### PR TITLE
feat: jwt 추가

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation("io.springfox:springfox-swagger2:2.9.2")
     implementation("io.springfox:springfox-swagger-ui:2.9.2")
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
+    implementation("com.auth0:java-jwt:3.18.1")
     testRuntimeOnly("com.h2database:h2")
 }
 

--- a/api/src/main/kotlin/mashup/backend/spring/member/application/authentication/TokenService.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/application/authentication/TokenService.kt
@@ -1,0 +1,6 @@
+package mashup.backend.spring.member.application.authentication
+
+interface TokenService<T> {
+    fun encode(memberId: T): String
+    fun decode(token: String?): T?
+}

--- a/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/jwt/JwtService.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/jwt/JwtService.kt
@@ -1,0 +1,40 @@
+package mashup.backend.spring.member.infrastructure.jwt
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.JWTVerifier
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.JWTVerificationException
+import mashup.backend.spring.member.application.authentication.TokenService
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+
+@Service
+class JwtService(
+    @Value("\${jwt.token-issuer}")
+    private val tokenIssuer: String,
+    @Value("\${jwt.token-signing-key}")
+    private val tokenSigningKey: String
+) : TokenService<Long> {
+    private val algorithm: Algorithm = Algorithm.HMAC256(tokenSigningKey)
+    private val jwtVerifier: JWTVerifier = JWT.require(algorithm).build()
+
+    override fun encode(memberId: Long): String {
+        return JWT.create()
+            .withIssuer(tokenIssuer)
+            .withClaim(CLAIM_NAME_MEMBER_ID, memberId)
+            .sign(algorithm)
+    }
+
+    override fun decode(token: String?): Long? {
+        return try {
+            jwtVerifier.verify(token)?.let { it.claims[CLAIM_NAME_MEMBER_ID]?.asLong() }
+        } catch (ex: JWTVerificationException) {
+            null
+        }
+    }
+
+    companion object {
+        private const val CLAIM_NAME_MEMBER_ID = "memberId"
+    }
+
+}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring.profiles: local
+jwt:
+  token-issuer: elegant-spring-member-local
+  token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
+---
+
+spring.profiles: develop
+jwt:
+  token-issuer: elegant-spring-member-develop
+  token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
+---
+
+spring.profiles: production
+jwt:
+  token-issuer: elegant-spring-member
+  token-signing-key: ENC(xiCQdjf+i0bNGRBqUP3H+FvYf0p5nRbFyXhV9CmJ6i0fgwUDmGINP1iV3X12ERXTw46RajdZp6v1y8DRZ40GpA==)
+---

--- a/api/src/test/kotlin/mashup/backend/spring/member/infrastructure/jwt/JwtServiceTest.kt
+++ b/api/src/test/kotlin/mashup/backend/spring/member/infrastructure/jwt/JwtServiceTest.kt
@@ -1,0 +1,46 @@
+package mashup.backend.spring.member.infrastructure.jwt
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+
+class JwtServiceTest {
+    private val sut: JwtService = JwtService(
+        tokenIssuer = "tokenIssuer",
+        tokenSigningKey = "tokenSigningKey"
+    )
+
+    @DisplayName("encode 성공")
+    @Test
+    fun encode() {
+        // given
+        val memberId = 1L
+        // when
+        val actual = sut.encode(memberId)
+        // then
+        assertThat(actual).isEqualTo("eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0b2tlbklzc3VlciIsIm1lbWJlcklkIjoxfQ.sqNkP_ZpWgvpYLg67hxa_6wKvBEvrsxJrSCRok8VNnc")
+    }
+
+    @DisplayName("decode 성공")
+    @Test
+    fun decodeSuccess() {
+        // given
+        val memberId = 1L
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0b2tlbklzc3VlciIsIm1lbWJlcklkIjoxfQ.sqNkP_ZpWgvpYLg67hxa_6wKvBEvrsxJrSCRok8VNnc"
+        // when
+        val actual = sut.decode(token)
+        // then
+        assertThat(actual).isEqualTo(memberId)
+    }
+
+    @DisplayName("decode 실패 - secret 일치하지 않음")
+    @Test
+    fun decodeFailure() {
+        // given
+        val token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJ0b2tlbklzc3VlciIsIm1lbWJlcklkIjoxfQ.NHtjs-Dh-KVIM78O3zTZMe2xtwKMvmtHkjWp5LzWI38"
+        // when
+        val actual = sut.decode(token)
+        // then
+        assertThat(actual).isNull()
+    }
+}


### PR DESCRIPTION
resolve #36 
- jwt encode, decode 기능 추가
- token 에는 memberId 값만 추가합니다. 다른 값 추가하게되면 수정 필요
- 어드민, 셀러 도 jwt 사용할지 논의필요