### PR TITLE
인증 기능 추가

### DIFF
--- a/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/spring/mvc/AuthenticationInterceptor.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/spring/mvc/AuthenticationInterceptor.kt
@@ -1,0 +1,63 @@
+package mashup.backend.spring.member.infrastructure.spring.mvc
+
+import mashup.backend.spring.member.application.authentication.TokenService
+import mashup.backend.spring.member.presentation.Authenticated
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.stereotype.Component
+import org.springframework.web.method.HandlerMethod
+import org.springframework.web.servlet.HandlerInterceptor
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+@ConditionalOnWebApplication
+@Component
+class AuthenticationInterceptor(
+    private val jwtService: TokenService<Long>
+) : HandlerInterceptor {
+
+    override fun preHandle(request: HttpServletRequest, response: HttpServletResponse, handler: Any): Boolean {
+        if (needsAuthentication(handler)) {
+            val memberId = authenticate(request)
+            request.setAttribute(MEMBER_ID, memberId)
+        }
+        return true
+    }
+
+    /**
+     * 인증이 필요한 요청인지 판단
+     */
+    private fun needsAuthentication(handler: Any): Boolean {
+        return if (handler is HandlerMethod) {
+            handler.getMethodAnnotation(Authenticated::class.java) != null
+                    || handler.beanType.getAnnotation(Authenticated::class.java) != null
+        } else {
+            false
+        }
+    }
+
+    /**
+     * 인증
+     */
+    private fun authenticate(request: HttpServletRequest): Long {
+        val accessToken = resolveAccessToken(request) ?: throw RuntimeException("AccessToken not found")
+        return jwtService.decode(accessToken) ?: throw RuntimeException("AccessToken is not valid")
+    }
+
+    /**
+     * Authorization: token {AccessToken}
+     */
+    private fun resolveAccessToken(request: HttpServletRequest): String? {
+        val authorizationHeader = request.getHeader(AUTHORIZATION_HEADER_NAME)
+        if (authorizationHeader == null || authorizationHeader.isBlank()) {
+            return null
+        }
+        val matchResult = REGEX_AUTHORIZATION_HEADER.find(authorizationHeader) ?: return null
+        return matchResult.groups[1]?.value
+    }
+
+    companion object {
+        private const val MEMBER_ID = "memberId"
+        private const val AUTHORIZATION_HEADER_NAME = "Authorization"
+        private val REGEX_AUTHORIZATION_HEADER = Regex("^token (.*)$")
+    }
+}

--- a/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/spring/mvc/MvcConfig.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/infrastructure/spring/mvc/MvcConfig.kt
@@ -1,0 +1,18 @@
+package mashup.backend.spring.member.infrastructure.spring.mvc
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@ConditionalOnWebApplication
+@Configuration
+class MvcConfig(
+    private val authenticationInterceptor: AuthenticationInterceptor
+) : WebMvcConfigurer {
+
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        super.addInterceptors(registry)
+        registry.addInterceptor(authenticationInterceptor)
+    }
+}

--- a/api/src/main/kotlin/mashup/backend/spring/member/presentation/Authenticated.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/presentation/Authenticated.kt
@@ -1,5 +1,5 @@
 package mashup.backend.spring.member.presentation
 
-@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
 @Retention(AnnotationRetention.RUNTIME)
 annotation class Authenticated

--- a/api/src/main/kotlin/mashup/backend/spring/member/presentation/Authenticated.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/presentation/Authenticated.kt
@@ -1,0 +1,5 @@
+package mashup.backend.spring.member.presentation
+
+@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class Authenticated

--- a/api/src/main/kotlin/mashup/backend/spring/member/presentation/GlobalControllerAdvice.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/presentation/GlobalControllerAdvice.kt
@@ -1,0 +1,14 @@
+package mashup.backend.spring.member.presentation
+
+import org.springframework.web.bind.annotation.ControllerAdvice
+import org.springframework.web.bind.annotation.ModelAttribute
+import javax.servlet.http.HttpServletRequest
+
+@ControllerAdvice
+class GlobalControllerAdvice {
+    @ModelAttribute("memberId")
+    fun resolveMemberId(request: HttpServletRequest): Long {
+        return request.getAttribute("memberId")?.let { it as Long }
+            ?: throw RuntimeException("'memberId' not found")
+    }
+}

--- a/api/src/main/kotlin/mashup/backend/spring/member/presentation/web/MainController.kt
+++ b/api/src/main/kotlin/mashup/backend/spring/member/presentation/web/MainController.kt
@@ -1,10 +1,27 @@
 package mashup.backend.spring.member.presentation.web
 
+import mashup.backend.spring.member.presentation.Authenticated
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import javax.servlet.http.HttpServletRequest
 
 @Controller
 class MainController {
+    @Authenticated
     @GetMapping("/main")
-    fun hello() = "main"
+    fun hello(
+        request: HttpServletRequest,
+        @ModelAttribute("memberId") memberId: Long
+    ): String {
+        log.info("memberId from RequestAttribute : ${request.getAttribute("memberId")}")
+        log.info("memberId from ModelAttribute   : $memberId")
+        return "main"
+    }
+
+    companion object {
+        val log: Logger = LoggerFactory.getLogger(this::class.java)
+    }
 }

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -1,16 +1,16 @@
-spring.profiles: local
+spring.config.activate.on-profile: local
 jwt:
   token-issuer: elegant-spring-member-local
   token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
 ---
 
-spring.profiles: develop
+spring.config.activate.on-profile: local
 jwt:
   token-issuer: elegant-spring-member-develop
   token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
 ---
 
-spring.profiles: production
+spring.config.activate.on-profile: local
 jwt:
   token-issuer: elegant-spring-member
   token-signing-key: ENC(xiCQdjf+i0bNGRBqUP3H+FvYf0p5nRbFyXhV9CmJ6i0fgwUDmGINP1iV3X12ERXTw46RajdZp6v1y8DRZ40GpA==)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -4,13 +4,13 @@ jwt:
   token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
 ---
 
-spring.config.activate.on-profile: local
+spring.config.activate.on-profile: develop
 jwt:
   token-issuer: elegant-spring-member-develop
   token-signing-key: ENC(48ETOHXvGqEUhmYWefuiN8VimeNuRE3XgYvO3SRBuCov0I8ssJ2/jzwcKwhxhvvR5X1p72l3RmfXVWRUs7Q//Q==)
 ---
 
-spring.config.activate.on-profile: local
+spring.config.activate.on-profile: production
 jwt:
   token-issuer: elegant-spring-member
   token-signing-key: ENC(xiCQdjf+i0bNGRBqUP3H+FvYf0p5nRbFyXhV9CmJ6i0fgwUDmGINP1iV3X12ERXTw46RajdZp6v1y8DRZ40GpA==)


### PR DESCRIPTION
resolve #35 

- Authorization 헤더를 통해 jwt 전달받아서 인증 처리 (포맷 : `Authorization: token {accessToken}`)
- 인터셉터를 통해 인증 처리
    - `@Authenticated` 어노테이션이 있는 컨트롤러 혹은 컨트롤러 메서드이면 인터셉터가 동작함. 없으면 통과함
    - 헤더가 없거나, 토큰 포맷이 기대하는 값과 다르거나, 토큰 파싱에 실패하면 예외 던짐
- Controller 에서는 request 객체의 attribute 나, modelAttribute 통해서 memberId 에 접근할 수 있음